### PR TITLE
add support for lists and enums

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -128,18 +128,28 @@ export function addModelFactoryParameterInterface(
 }
 
 export function getModelDefaultValueVariableInitializer(model: DMMF.Model) {
-  return Object.fromEntries(
-    model.fields
-      .filter((field) => !field.isId)
-      .filter((field) => field.kind === 'scalar')
-      .filter((field) => {
-        return !model.fields.find((it) => {
-          return it.relationFromFields?.includes(field.name)
-        })
+  const fields = model.fields
+    .filter((field) => !field.isId)
+    .filter((field) => field.kind === 'scalar')
+    .filter((field) => {
+      return !model.fields.find((it) => {
+        return it.relationFromFields?.includes(field.name)
       })
-      .filter((field) => !field.hasDefaultValue)
-      .map((field) => [field.name, fakerForField(field)])
-  )
+    })
+    .filter((field) => !field.hasDefaultValue)
+  return Object.fromEntries([
+    ...fields
+      .filter((field) => !field.isList)
+      .map((field) => [field.name, fakerForField(field)]),
+    ...fields
+      .filter((field) => field.isList)
+      .map((field) => [
+        field.name,
+        `[${fakerForField(field)},${fakerForField(field)},${fakerForField(
+          field
+        )}]`,
+      ]),
+  ])
 }
 
 function getAttributesForFunctionName(model: DMMF.Model) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -94,19 +94,21 @@ function getModelFactoryParameterInterfaceName(model: DMMF.Model) {
 }
 export function addModelAttributeForFunction(
   sourceFile: SourceFile,
-  model: DMMF.Model
+  model: DMMF.Model,
+  enums: DMMF.DatamodelEnum[]
 ) {
   sourceFile.addFunction({
     isExported: true,
     name: getAttributesForFunctionName(model),
     statements: (writer) => {
       writer.write('return').block(() => {
-        const initializer = getModelDefaultValueVariableInitializer(model)
-        Object.keys(getModelDefaultValueVariableInitializer(model)).map(
-          (key) => {
-            writer.write(`${key}: ${initializer[key]},`)
-          }
+        const initializer = getModelDefaultValueVariableInitializer(
+          model,
+          enums
         )
+        Object.keys(initializer).map((key) => {
+          writer.write(`${key}: ${initializer[key]},`)
+        })
       })
     },
   })
@@ -127,28 +129,32 @@ export function addModelFactoryParameterInterface(
   return Object.keys(properties).some((key) => !key.endsWith('?'))
 }
 
-export function getModelDefaultValueVariableInitializer(model: DMMF.Model) {
-  const fields = model.fields
+export function getModelDefaultValueVariableInitializer(
+  model: DMMF.Model,
+  enums: DMMF.DatamodelEnum[]
+) {
+  const validFields = model.fields
     .filter((field) => !field.isId)
-    .filter((field) => field.kind === 'scalar')
+    .filter((field) => field.kind === 'scalar' || field.kind === 'enum')
     .filter((field) => {
       return !model.fields.find((it) => {
         return it.relationFromFields?.includes(field.name)
       })
     })
     .filter((field) => !field.hasDefaultValue)
+
+  const nonListFields = validFields.filter((field) => !field.isList)
+  const listFields = validFields.filter((field) => field.isList)
+
   return Object.fromEntries([
-    ...fields
-      .filter((field) => !field.isList)
-      .map((field) => [field.name, fakerForField(field)]),
-    ...fields
-      .filter((field) => field.isList)
-      .map((field) => [
-        field.name,
-        `[${fakerForField(field)},${fakerForField(field)},${fakerForField(
-          field
-        )}]`,
-      ]),
+    ...nonListFields.map((field) => [field.name, fakerForField(field, enums)]),
+    ...listFields.map((field) => [
+      field.name,
+      `[${fakerForField(field, enums)},${fakerForField(
+        field,
+        enums
+      )},${fakerForField(field, enums)}]`,
+    ]),
   ])
 }
 
@@ -159,10 +165,11 @@ function getAttributesForFunctionName(model: DMMF.Model) {
 export function addModelFactoryDeclaration(
   sourceFile: SourceFile,
   model: DMMF.Model,
-  models: DMMF.Model[]
+  models: DMMF.Model[],
+  enums: DMMF.DatamodelEnum[]
 ) {
   const modelName = model.name
-  addModelAttributeForFunction(sourceFile, model)
+  addModelAttributeForFunction(sourceFile, model, enums)
   args(sourceFile, model, models)
   const isRequired = hasRequiredRelation(model, models)
   sourceFile.addFunction({

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -41,9 +41,10 @@ export function fakerForField(field: DMMF.Field, enums: DMMF.DatamodelEnum[]) {
     const enumName = fieldType
     const enumValues = enums.find((it) => it.name === enumName)?.values
     if (enumValues?.length) {
-      const randomIndex = Math.floor(Math.random() * enumValues.length)
-      const enumValue = enumValues[randomIndex]
-      return `'${enumValue.dbName || enumValue.name}'`
+      //if we have at least one enum value
+      return `[${enumValues
+        .map((v) => `'${v.dbName || v.name}'`)
+        .join(', ')}][Math.floor(Math.random() * ${enumValues.length})]`
     }
   }
   throw new Error(`${fieldType} isn't supported. kind: ${fieldKind}`)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -13,7 +13,7 @@ export function fakerForStringField(fieldName: string) {
   return 'faker.name.title()'
 }
 
-export function fakerForField(field: DMMF.Field) {
+export function fakerForField(field: DMMF.Field, enums: DMMF.DatamodelEnum[]) {
   const fieldType = field.type
   const fieldKind = field.kind
   if (fieldType === 'String') {
@@ -36,6 +36,15 @@ export function fakerForField(field: DMMF.Field) {
   }
   if (fieldType === 'Json') {
     return 'faker.datatype.json()'
+  }
+  if (fieldKind === 'enum') {
+    const enumName = fieldType
+    const enumValues = enums.find((it) => it.name === enumName)?.values
+    if (enumValues?.length) {
+      const randomIndex = Math.floor(Math.random() * enumValues.length)
+      const enumValue = enumValues[randomIndex]
+      return `'${enumValue.dbName || enumValue.name}'`
+    }
   }
   throw new Error(`${fieldType} isn't supported. kind: ${fieldKind}`)
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -43,7 +43,7 @@ export function fakerForField(field: DMMF.Field, enums: DMMF.DatamodelEnum[]) {
     if (enumValues?.length) {
       //if we have at least one enum value
       const enumValuesAsString = enumValues.map((v) => `'${v.name}'`).join(', ')
-      return `faker.helpers.arrayElement([${enumValuesAsString}])`
+      return `faker.random.arrayElement([${enumValuesAsString}])`
     }
   }
   throw new Error(`${fieldType} isn't supported. kind: ${fieldKind}`)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -42,9 +42,8 @@ export function fakerForField(field: DMMF.Field, enums: DMMF.DatamodelEnum[]) {
     const enumValues = enums.find((it) => it.name === enumName)?.values
     if (enumValues?.length) {
       //if we have at least one enum value
-      return `[${enumValues
-        .map((v) => `'${v.dbName || v.name}'`)
-        .join(', ')}][Math.floor(Math.random() * ${enumValues.length})]`
+      const enumValuesAsString = enumValues.map((v) => `'${v.name}'`).join(', ')
+      return `faker.helpers.arrayElement([${enumValuesAsString}])`
     }
   }
   throw new Error(`${fieldType} isn't supported. kind: ${fieldKind}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,9 @@ generatorHandler({
       )
       addPrismaImportDeclaration(sourceFile)
       const models = options.dmmf.datamodel.models
+      const enums = options.dmmf.datamodel.enums
       options.dmmf.datamodel.models.forEach((model) => {
-        addModelFactoryDeclaration(sourceFile, model, models)
+        addModelFactoryDeclaration(sourceFile, model, models, enums)
       })
       sourceFile.formatText({
         indentSize: 2,

--- a/src/tests/__snapshots__/sample.test.ts.snap
+++ b/src/tests/__snapshots__/sample.test.ts.snap
@@ -8,7 +8,7 @@ const prisma = new PrismaClient()
 
 export function inputsForUser() {
   return {
-    email: faker.internet.email(), jsonProp: faker.datatype.json(), stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
+    email: faker.internet.email(), jsonProp: faker.datatype.json(), status: 'active', stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
   }
 }
 

--- a/src/tests/__snapshots__/sample.test.ts.snap
+++ b/src/tests/__snapshots__/sample.test.ts.snap
@@ -8,7 +8,7 @@ const prisma = new PrismaClient()
 
 export function inputsForUser() {
   return {
-    email: faker.internet.email(), jsonProp: faker.datatype.json(),
+    email: faker.internet.email(), jsonProp: faker.datatype.json(), stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
   }
 }
 

--- a/src/tests/__snapshots__/sample.test.ts.snap
+++ b/src/tests/__snapshots__/sample.test.ts.snap
@@ -8,7 +8,7 @@ const prisma = new PrismaClient()
 
 export function inputsForUser() {
   return {
-    email: faker.internet.email(), jsonProp: faker.datatype.json(), status: 'active', stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
+    email: faker.internet.email(), jsonProp: faker.datatype.json(), status: ['active'][Math.floor(Math.random() * 1)], stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
   }
 }
 

--- a/src/tests/__snapshots__/sample.test.ts.snap
+++ b/src/tests/__snapshots__/sample.test.ts.snap
@@ -8,7 +8,7 @@ const prisma = new PrismaClient()
 
 export function inputsForUser() {
   return {
-    email: faker.internet.email(), jsonProp: faker.datatype.json(), status: ['active'][Math.floor(Math.random() * 1)], stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
+    email: faker.internet.email(), jsonProp: faker.datatype.json(), status: faker.helpers.arrayElement(['active']), stringArray: [faker.name.title(), faker.name.title(), faker.name.title()],
   }
 }
 

--- a/src/tests/defaultValue.test.ts
+++ b/src/tests/defaultValue.test.ts
@@ -30,12 +30,14 @@ let dmmf: DMMF.Document
 let userModel: DMMF.Model
 let accessTokenModel: DMMF.Model
 let initializer: Record<string, any>
+let enums: DMMF.DatamodelEnum[]
 
 beforeAll(async () => {
   dmmf = await getDMMF({ datamodel })
   userModel = dmmf.datamodel.models[0]
   accessTokenModel = dmmf.datamodel.models[1]
-  initializer = getModelDefaultValueVariableInitializer(accessTokenModel)
+  enums = dmmf.datamodel.enums
+  initializer = getModelDefaultValueVariableInitializer(accessTokenModel, enums)
 })
 
 test('@id field is not generate', () => {
@@ -58,6 +60,6 @@ test('set @default field is not generate', () => {
 test('snapshot', () => {
   const project = new Project()
   const sourceFile = project.createSourceFile('tmp')
-  addModelAttributeForFunction(sourceFile, userModel)
+  addModelAttributeForFunction(sourceFile, userModel, enums)
   expect(sourceFile.getText()).toMatchSnapshot()
 })

--- a/src/tests/sample.test.ts
+++ b/src/tests/sample.test.ts
@@ -5,11 +5,19 @@ import {
 } from '../generator'
 import { Project, ts } from 'ts-morph'
 const datamodel = /* Prisma */ `
+
+datasource db {
+  ///sqlite doesn't support String[]
+  provider = "postgresql"
+  url="postgresql://test:test@localhost:5432/test"
+}
+
 model User {
-  id          Int          @id @default(autoincrement())
-  email       String       @unique
-  jsonProp    Json
-  accessToken AccessToken?
+  id                Int          @id @default(autoincrement())
+  email             String       @unique
+  stringArray       String[]       
+  jsonProp          Json
+  accessToken       AccessToken?
 
   @@map(name: "users")
 }

--- a/src/tests/sample.test.ts
+++ b/src/tests/sample.test.ts
@@ -17,9 +17,14 @@ model User {
   email             String       @unique
   stringArray       String[]       
   jsonProp          Json
+  status            UserStatus
   accessToken       AccessToken?
 
   @@map(name: "users")
+}
+
+enum UserStatus {
+  active
 }
 
 model AccessToken {
@@ -41,7 +46,12 @@ test('generate model', async () => {
   const dmmf = await getDMMF({ datamodel })
   addPrismaImportDeclaration(sourceFile)
   dmmf.datamodel.models.forEach((model) => {
-    addModelFactoryDeclaration(sourceFile, model, dmmf.datamodel.models)
+    addModelFactoryDeclaration(
+      sourceFile,
+      model,
+      dmmf.datamodel.models,
+      dmmf.datamodel.enums
+    )
   })
 
   sourceFile.formatText({


### PR DESCRIPTION
fix #17 

- right now, I'm hard coding 3 array items. we can potentially improve that with a dynamic value so you can add N array items

@toyamarinyon let me know what you think.

Overall, I found the codebase to be very easy to navigate, but I wish we could pass the entire datamodel around instead of passing only the models. That's why I sent the enums in a different parameter. if you feel like it'd be better to pass the entire model around, let me know and I can refactor.