### PR TITLE
Fix factory generated Prisma model name camelcase

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "scripts": {
     "build": "swc src -d dist",
     "test": "jest",
-    "dev": "ts-node example/test-run.ts"
+    "dev": "ts-node example/test-run.ts",
+    "prepare": "yarn build"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,6 +1,6 @@
 import { DMMF } from '@prisma/client/runtime'
 import camelcase from 'camelcase'
-import { fakerForField } from './helper'
+import { fakerForField, lowerCase } from './helper'
 import { SourceFile } from 'ts-morph'
 import { args, factoryArgsTypeName } from './args'
 import { hasRequiredRelation } from './relation'
@@ -166,7 +166,7 @@ export function addModelFactoryDeclaration(
       },
     ],
     statements: `
-      return await prisma.${camelcase(modelName)}.create({
+      return await prisma.${lowerCase(modelName)}.create({
         ...args,
         data: {
           ...${getAttributesForFunctionName(model)}(),

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -39,3 +39,7 @@ export function fakerForField(field: DMMF.Field) {
   }
   throw new Error(`${fieldType} isn't supported. kind: ${fieldKind}`)
 }
+
+export function lowerCase(name: string): string {
+  return name.substring(0, 1).toLowerCase() + name.substring(1)
+}

--- a/src/tests/__snapshots__/sample.test.ts.snap
+++ b/src/tests/__snapshots__/sample.test.ts.snap
@@ -34,7 +34,7 @@ export function inputsForAccessToken() {
 }
 
 type AccessTokenFactoryArgs = Omit<Prisma.AccessTokenCreateArgs, 'data'> & {
-  data: Pick<Prisma.AccessTokenCreateInput, 'user'> & Partial<Omit<Prisma.AccessTokenCreateInput, 'user'>>
+  data: Pick<Prisma.AccessTokenCreateInput, 'user' | 'v2User'> & Partial<Omit<Prisma.AccessTokenCreateInput, 'user' | 'v2User'>>
 }
 
 export async function createAccessToken(args: AccessTokenFactoryArgs) {
@@ -43,6 +43,28 @@ export async function createAccessToken(args: AccessTokenFactoryArgs) {
     ...args,
     data: {
       ...inputsForAccessToken(),
+      ...args?.data
+    },
+  })
+
+}
+
+export function inputsForV2User() {
+  return {
+    email: faker.internet.email(), jsonProp: faker.datatype.json(),
+  }
+}
+
+type V2UserFactoryArgs = Omit<Prisma.V2UserCreateArgs, 'data'> & {
+  data: Pick<Prisma.V2UserCreateInput, 'accessToken'> & Partial<Omit<Prisma.V2UserCreateInput, 'accessToken'>>
+}
+
+export async function createV2User(args?: V2UserFactoryArgs) {
+
+  return await prisma.v2_User.create({
+    ...args,
+    data: {
+      ...inputsForV2User(),
       ...args?.data
     },
   })

--- a/src/tests/sample.test.ts
+++ b/src/tests/sample.test.ts
@@ -18,8 +18,19 @@ model AccessToken {
   id          Int       @id @default(autoincrement())
   user        User      @relation(fields: [userId], references: [id])
   userId      Int       @unique @map(name: "user_id")
+  v2User      V2_User   @relation(fields: [v2UserId], references: [id])
+  v2UserId    Int       @unique @map(name: "v2_user_id")
 
   @@map("access_tokens")
+}
+
+model V2_User {
+  id          Int          @id @default(autoincrement())
+  email       String       @unique
+  jsonProp    Json
+  accessToken AccessToken?
+
+  @@map(name: "v2_users")
 }
 `
 


### PR DESCRIPTION
1. Fixes https://github.com/toyamarinyon/prisma-factory-generator/issues/25
2. Add `prepare` scripts in package.json to allow install from git